### PR TITLE
Return the correct offset after a user-requested stop

### DIFF
--- a/mewjson.c
+++ b/mewjson.c
@@ -802,6 +802,7 @@ static int parserFinish(struct ParseState *s, enum State state, const char **ptr
 {
     if (ISSPACE(peekChar(ptr))) {
         skipWhitespace(ptr);
+        ungetChar(ptr);
     }
     if (state == kStateStop) {
         s->status = kStatusStopped;

--- a/test/test.c
+++ b/test/test.c
@@ -1133,7 +1133,7 @@ static void testCheckLiteral(const char *input, JsonBool expectNull, JsonBool bo
 
 static void testcaseLiteralIdentity(void)
 {
-    testcaseInit("number_real");
+    testcaseInit("literal_identity");
     testCheckLiteral("null", 1, 0);
     testCheckLiteral("false", 0, 0);
     testCheckLiteral("true", 0, 1);
@@ -1154,6 +1154,7 @@ static void testCheckUtf8(const char *input, JsonBool expectOk)
 
 static void testcaseUtf8(void)
 {
+    testcaseInit("utf8");
     static const struct {
         const char *text;
         JsonBool isValid;
@@ -1249,8 +1250,36 @@ static void testcaseUtf8(void)
     }
 }
 
+static JsonBool multiDocEndContainer(void *ctx, JsonBool isObject)
+{
+    (void)ctx;
+    (void)isObject;
+    return 0; // Stop on the first ']' or '}'
+}
+
+static void testcaseMultipleDocs(void)
+{
+    testcaseInit("multiple_docs");
+    static const char kInput[] = "{\"a\":1} [true]\n{}\r\n[1,2,3]     {\"b\":1}";
+    JsonSize length = SIZEOF(kInput) - 1;
+    struct JsonParser parser;
+    struct TestcaseContext ctx;
+    testParserInit(&parser, &ctx);
+    parser.h.endContainer = multiDocEndContainer;
+
+    const char *ptr = kInput;
+    while (length > 0) {
+        enum JsonStatus s = jsonParse(ptr, length, &parser);
+        CHECK(s == kStatusStopped);
+        length -= parser.offset;
+        ptr += parser.offset;
+    }
+}
+
 int main(void)
 {
+    testcaseMultipleDocs();
+
     puts("* * * running mewjson tests * * *");
 
     sanityCheckRealEquality();


### PR DESCRIPTION
Add a test that parses multiple documents from the same string.